### PR TITLE
[IMP] Popover: Optimized if the trigger is click. When selecting the …

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -25,12 +25,15 @@ timeline: true
 - 💄 `<pro>Table`: Optimize the performance of editors.
 - 💄 `<pro>Table`: Optimize virtual scrolling performance.
 - 💄 `<pro>Table`: Optimize ProfessionalBar The query field of type boolean is displayed as a checkBox by default.
+- 💄 `Popover`: Optimized if the trigger is click. When selecting the Select component in the pop-up window, you don't need to set getPopupContainer to prevent the pop-up window from closing.
+- 💄 `<pro>Trigger`: Optimize the getContainer method.
 - 🐞 `<pro>DatePicker`: Fix the incorrect restriction of `maxLength` and `minLength`.
 - 🐞 `<pro>NumberField`: Fix the incorrect restriction of `maxLength` and `minLength`.
 - 🐞 `<pro>DataSet.Field`: Fix the incorrect restriction of `maxLength` and `minLength` on date and number types.
 - 🐞 `<pro>DataSet.Field`: Fix the issue of freezing when dynamicProps.lovPara and cascadeMap are used at the same time.
 - 🐞 `<pro>Modal`: Fix some abnormal behaviors of Modal which not provided by ModalProvider.
 - 🐞 `<pro>Table`: Fix the problem that the input number will not be displayed in a new line when rowHeight:auto.
+- 🐞 `<pro>Tooltip`: Fix the problem that the position is offset when it is displayed for the first time.
 
 ## 1.3.0
 

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -25,12 +25,15 @@ timeline: true
 - 💄 `<pro>Table`: 优化编辑器性能。
 - 💄 `<pro>Table`: 优化虚拟滚动性能。
 - 💄 `<pro>Table`: 优化 ProfessionalBar 查询条 boolean 类型的查询字段默认显示为勾选框。
+- 💄 `Popover`: 优化 trigger 为 click 模式下，弹窗中 Select 组件选择时无需设置 getPopupContainer 也能防止弹窗关闭。
+- 💄 `<pro>Trigger`: 优化 getContainer 方式。
 - 🐞 `<pro>DatePicker`: 修复 maxLength 和 minLength 的错误限制。
 - 🐞 `<pro>NumberField`: 修复 maxLength 和 minLength 的错误限制。
 - 🐞 `<pro>DataSet.Field`：修复 maxLength 和 minLength 对日期和数字类型的错误限制及校验。
 - 🐞 `<pro>DataSet.Field`：修复 dynamicProps.lovPara 和 cascadeMap 同时使用时卡顿的问题。
 - 🐞 `<pro>Modal`：修复非 ModalProvider 提供的 Modal 的一些异常行为。
 - 🐞 `<pro>Table`：修复 rowHeight:auto 时，输入数字不会换行显示的问题。
+- 🐞 `<pro>Tooltip`：修复第一次显示时位置有偏移的问题。
 
 
 ## 1.3.0

--- a/components-pro/pagination/Pagination.tsx
+++ b/components-pro/pagination/Pagination.tsx
@@ -300,7 +300,7 @@ export default class Pagination extends DataSetComponent<PaginationProps> {
   }
 
   @action
-  getOptions(): [ReactNode, number] {
+  getOptions(): ReactNode {
     const { Option } = ObserverSelect;
     return this.options.map(option => (
       <Option key={option} value={option}>

--- a/components-pro/tooltip/style/index.less
+++ b/components-pro/tooltip/style/index.less
@@ -9,6 +9,7 @@
   position: absolute;
   z-index: 1;
   display: block;
+  padding: @tooltip-distance;
   background-color: transparent !important;
   box-shadow: none !important;
   visibility: visible;
@@ -20,25 +21,29 @@
   &-placement-top,
   &-placement-topLeft,
   &-placement-topRight {
-    padding-bottom: @tooltip-distance;
+    padding-right: 0;
+    padding-left: 0;
   }
 
   &-placement-right,
   &-placement-rightTop,
   &-placement-rightBottom {
-    padding-left: @tooltip-distance;
+    padding-top: 0;
+    padding-bottom: 0;
   }
 
   &-placement-bottom,
   &-placement-bottomLeft,
   &-placement-bottomRight {
-    padding-top: @tooltip-distance;
+    padding-right: 0;
+    padding-left: 0;
   }
 
   &-placement-left,
   &-placement-leftTop,
   &-placement-leftBottom {
-    padding-right: @tooltip-distance;
+    padding-top: 0;
+    padding-bottom: 0;
   }
 
   // Wrapper for the tooltip content

--- a/components-pro/trigger/Trigger.tsx
+++ b/components-pro/trigger/Trigger.tsx
@@ -158,6 +158,8 @@ export default class Trigger extends Component<TriggerProps> {
 
   @observable popupHidden?: boolean;
 
+  @observable mounted?: boolean;
+
   constructor(props, context) {
     super(props, context);
     runInAction(() => {
@@ -207,6 +209,11 @@ export default class Trigger extends Component<TriggerProps> {
     if (popupHidden !== this.popupHidden && popupHidden !== undefined) {
       this.popupHidden = popupHidden;
     }
+  }
+
+  @mobxAction
+  componentDidMount() {
+    this.mounted = true;
   }
 
   componentDidUpdate() {
@@ -340,40 +347,42 @@ export default class Trigger extends Component<TriggerProps> {
       getPopupContainer,
       onMouseDown = this.handlePopupMouseDown,
     } = this.props;
-    if (popupContent) {
-      const visible = !this.popupHidden;
-      const mouseProps: any = {};
-      if (this.isMouseEnterToShow()) {
-        mouseProps.onMouseEnter = this.handlePopupMouseEnter;
+    if (this.mounted || !getPopupContainer) {
+      if (popupContent) {
+        const visible = !this.popupHidden;
+        const mouseProps: any = {};
+        if (this.isMouseEnterToShow()) {
+          mouseProps.onMouseEnter = this.handlePopupMouseEnter;
+        }
+        if (this.isMouseLeaveToHide()) {
+          mouseProps.onMouseLeave = this.handlePopupMouseLeave;
+        }
+        return (
+          <Popup
+            key="popup"
+            ref={this.saveRef}
+            transitionName={transitionName}
+            className={classNames(`${prefixCls}-popup`, popupCls, popupClassName)}
+            style={popupStyle}
+            hidden={!visible}
+            align={this.getPopupAlign()}
+            onAlign={onPopupAlign}
+            onMouseDown={onMouseDown}
+            onMouseUp={this.handlePopupMouseUp}
+            getRootDomNode={getRootDomNode}
+            onAnimateAppear={onPopupAnimateAppear}
+            onAnimateEnter={onPopupAnimateEnter}
+            onAnimateLeave={onPopupAnimateLeave}
+            onAnimateEnd={onPopupAnimateEnd}
+            getStyleFromAlign={getPopupStyleFromAlign}
+            getClassNameFromAlign={this.getPopupClassNameFromAlign}
+            getPopupContainer={getPopupContainer}
+            {...mouseProps}
+          >
+            {popupContent}
+          </Popup>
+        );
       }
-      if (this.isMouseLeaveToHide()) {
-        mouseProps.onMouseLeave = this.handlePopupMouseLeave;
-      }
-      return (
-        <Popup
-          key="popup"
-          ref={this.saveRef}
-          transitionName={transitionName}
-          className={classNames(`${prefixCls}-popup`, popupCls, popupClassName)}
-          style={popupStyle}
-          hidden={!visible}
-          align={this.getPopupAlign()}
-          onAlign={onPopupAlign}
-          onMouseDown={onMouseDown}
-          onMouseUp={this.handlePopupMouseUp}
-          getRootDomNode={getRootDomNode}
-          onAnimateAppear={onPopupAnimateAppear}
-          onAnimateEnter={onPopupAnimateEnter}
-          onAnimateLeave={onPopupAnimateLeave}
-          onAnimateEnd={onPopupAnimateEnd}
-          getStyleFromAlign={getPopupStyleFromAlign}
-          getClassNameFromAlign={this.getPopupClassNameFromAlign}
-          getPopupContainer={getPopupContainer}
-          {...mouseProps}
-        >
-          {popupContent}
-        </Popup>
-      );
     }
   }
 

--- a/components/rc-components/trigger/index.jsx
+++ b/components/rc-components/trigger/index.jsx
@@ -231,9 +231,11 @@ export default class Trigger extends Component {
 
   onBlur = (e) => {
     this.fireEvents('onBlur', e);
-    this.clearDelayTimer();
-    if (this.isBlurToHide()) {
-      this.delaySetPopupVisible(false, this.props.blurDelay);
+    if (!e.isDefaultPrevented()) {
+      this.clearDelayTimer();
+      if (this.isBlurToHide()) {
+        this.delaySetPopupVisible(false, this.props.blurDelay);
+      }
     }
   };
 
@@ -276,7 +278,7 @@ export default class Trigger extends Component {
   };
 
   onDocumentClick = (event) => {
-    if (this.props.mask && !this.props.maskClosable) {
+    if (event.isDefaultPrevented() || (this.props.mask && !this.props.maskClosable)) {
       return;
     }
     const target = event.target;
@@ -500,9 +502,11 @@ export default class Trigger extends Component {
     if (childCallback) {
       childCallback(e);
     }
-    const callback = this.props[type];
-    if (callback) {
-      callback(e);
+    if (!e.isDefaultPrevented()) {
+      const callback = this.props[type];
+      if (callback) {
+        callback(e);
+      }
     }
   }
 
@@ -517,8 +521,7 @@ export default class Trigger extends Component {
   render() {
     const { popupVisible } = this.state;
     const props = this.props;
-    const children = props.children;
-    const child = Children.only(children);
+    const child = Children.only(props.children);
     const newChildProps = { key: 'trigger' };
 
     if (this.isContextMenuToShow()) {


### PR DESCRIPTION
[IMP] Popover: Optimized if the trigger is click. When selecting the Select component in the pop-up window, you don't need to set getPopupContainer to prevent the pop-up window from closing. 
[IMP] <pro>Trigger: Optimize the getContainer method.
[FIX] <pro>Tooltip: Fix the problem that the position is offset when it is displayed for the first time.