### PR TITLE
[FIX] <pro>Table: Fix the issue that under the peacock blue theme, wh…

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -24,6 +24,7 @@ timeline: true
 - 💄 `<pro>Table`: Optimize the performance.
 - 🐞 `<pro>Pagination`: Fix the problem that the pagination option exceeds the default maximum of 100 pagination when the maximum pagination is not set.
 - 🐞 `<pro>IconPicker`: Fix the problem that the pop-up window cannot be closed when the pagination button is clicked and the button is disabled.
+- 🐞 `<pro>Table`: Fix the issue that under the peacock blue theme, when the editor of the Column is function, after entering the editing mode and clicking exit, the width of the component in the editing mode will be incorrect next time.
 
 ## 1.4.1
 

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -24,6 +24,7 @@ timeline: true
 - 💄 `<pro>Table`：优化性能。
 - 🐞 `<pro>Pagination`: 修复最大分页没有设置时，分页选项有超过默认最大100分页无法选择的问题。
 - 🐞 `<pro>IconPicker`: 修复当点击分页按钮并按钮成禁用状态时，弹窗无法关闭的问题。
+- 🐞 `<pro>Table`: 修复在孔雀蓝主题下，当Column的editor为function的时候，进入编辑态点击退出后会导致下次进入编辑态组件宽度不正确的问题
 
 ## 1.4.1
 

--- a/components-pro/table/TableWrapper.tsx
+++ b/components-pro/table/TableWrapper.tsx
@@ -152,7 +152,10 @@ export default class TableWrapper extends Component<TableWrapperProps, any> {
 
   getEditors() {
     return this.leafEditorColumns.map(column => (
-      <TableEditor key={getColumnKey(column)} column={column} />
+      <TableEditor
+        key={(typeof column.editor === 'function') ?
+          `${getColumnKey(column)}+${Math.random()}` : getColumnKey(column)}
+        column={column} />
     ));
   }
 


### PR DESCRIPTION
…en the editor of the Column is function, after entering the editing mode and clicking exit, the width of the component in the editing mode will be incorrect next time.