### PR TITLE
[FIX] enable typescript-eslint recommended rules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,6 +2,8 @@ const eslintrc = {
   extends: [
     'airbnb',
     'prettier',
+    'plugin:@typescript-eslint/eslint-recommended',
+    'plugin:@typescript-eslint/recommended',
     'plugin:jest/recommended',
     'plugin:react/recommended',
     'plugin:import/typescript',


### PR DESCRIPTION
It puzzles me why you've installed typescript-eslint but haven't enabled any rule except for `no-unused-vars`, which is essentially the same as the ESLint one.

Also there's no CI to check linting status, might make one in a followup PR :D

P.S. There's no CONTRIBUTING guide either, and your commit message convention isn't really the canonical semantic commits, so not really contributor-friendly IMO (this PR probably shouldn't be [FIX] for example, but can't find a better title). Do you plan to write a contributing guide any time soon?