### PR TITLE
[ADD] <pro>Attachment: Added downloadAllMode, getDownloadAllUrl, getD…

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -34,6 +34,7 @@ timeline: true
 - 🌟 `<pro>DataSet.Field`: The `trueValue` and `falseValue` attributes add array types.
 - 🌟 `<pro>Table`: Added `addNewButton` property.
 - 🌟 `<pro>Table`: Personalized new bottom function.
+- 🌟 `<pro>Attachment`: Added `downloadAllMode`, `getDownloadAllUrl`, `getDownloadUrl` properties.
 - 💄 `<pro>Tree`: Optimizes the default value of `showLeafIcon` when `showLine` is true.
 - 💄 `<pro>Table`: Optimize sorting attributes, remove `showSortOption`, and add `currentDataSort` and `allDataSort` attributes.
 - 💄 `<pro>SelectBox`: Optimized the removal of focus styles in read-only mode.
@@ -64,6 +65,7 @@ timeline: true
 - 💄 `<pro>Pagination`: Optimized the restriction of the number type input field for quick jumps.
 - 💄 `<pro>Picture`: Optimize the judgment of `loading` state.
 - 💄 `<pro>Table`: The optimized row number column supports custom `onCell` Settings.
+- 💄 `<pro>Attachment`: The upload failed and `Tooltip` is displayed if the error text is too long.
 - 🐞 `<pro>Attachment`: Fixed the issue that no file was echoed after a multipart upload was successful.
 - 🐞 `<pro>Table`: Fixed the issue that there was no line break in the long text in the cell of auto rowHeight.
 - 🐞 `<pro>Table`: Fixed the issue of copying the lov single choice type as empty in bidirectional replication.
@@ -92,6 +94,7 @@ timeline: true
 - 🐞 `<pro>Modal`: Fix the global `modalResizable` configuration does not take effect.
 - 🐞 `<pro>Button`: Fixed an issue where the `Tooltip` on the button would not disappear after clicking the button with the icon to open `Modal` asynchronously.
 - 🐞 `<pro>CheckBox`: Fixed the issue that setting `trueValue` and `falseValue` with `dynamicProps` would cause `CheckBox` to fail to be checked.
+- 🐞 `<pro>Tree`: Fixed an issue where the checked node expansion would be unchecked when the `dataSet` set the `treeCheckStrictly` property.
 
 ## 1.6.6
 

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -34,6 +34,7 @@ timeline: true
 - 🌟 `<pro>DataSet.Field`: trueValue 和 falseValue 属性新增数组类型。
 - 🌟 `<pro>Table`: 新增 addNewButton 属性。
 - 🌟 `<pro>Table`: 个性化新增置底功能。
+- 🌟 `<pro>Attachment`: 新增 downloadAllMode, getDownloadAllUrl, getDownloadUrl 属性。
 - 💄 `<pro>Tree`: 优化 showLine 属性为 true 时的 showLeafIcon 默认值。
 - 💄 `<pro>Table`: 优化排序属性，废弃 showSortOption，新增 currentDataSort、allDataSort 属性。
 - 💄 `<pro>SelectBox`: 优化去除只读状态下的聚焦样式。
@@ -64,6 +65,7 @@ timeline: true
 - 💄 `<pro>Pagination`: 优化快速跳转数字输入框限制。
 - 💄 `<pro>Picture`: 优化 loading 状态的判断。
 - 💄 `<pro>Table`: 优化行号列支持自定义设置 onCell。
+- 💄 `<pro>Attachment`: 上传失败, 报错文本超长时显示 Tooltip。
 - 🐞 `<pro>Attachment`: 修复分片上传成功没有回显文件的问题。
 - 🐞 `<pro>Table`: 修复自动行高下复制到单元格的长文本没有换行的问题。
 - 🐞 `<pro>Table`: 修复双向复制 lov 单选类型复制为空的问题。
@@ -92,6 +94,7 @@ timeline: true
 - 🐞 `<pro>Modal`: 修复全局配置 modalResizable 不生效的问题。
 - 🐞 `<pro>Button`: 修复点击带图标的按钮异步打开 Modal 后按钮上的 Tooltip 不会消失的问题。
 - 🐞 `<pro>CheckBox`: 修复使用动态属性设置 trueValue 和 falseValue 会导致无法勾选的问题。
+- 🐞 `<pro>Tree`: 修复 dataSet 设置 treeCheckStrictly 属性时, 勾选的节点展开会被取消勾选的问题。
 
 ## 1.6.6
 

--- a/components-pro/attachment/Attachment.tsx
+++ b/components-pro/attachment/Attachment.tsx
@@ -92,6 +92,9 @@ export interface AttachmentProps extends FormFieldProps, ButtonProps, UploaderPr
   Modal?: ModalContextValue;
   removeConfirm?: boolean | PopconfirmProps;
   templateDownloadButtonRenderer?: () => ReactNode;
+  downloadAllMode?: DownloadAllMode;
+  getDownloadAllUrl?: (props: AttachmentValue) => string | Function | undefined;
+  getDownloadUrl?: (props: AttachmentFileProps) => string | Function | undefined;
 }
 
 export type Sort = {
@@ -1020,7 +1023,7 @@ export default class Attachment extends FormField<AttachmentProps> {
 
   renderUploadList(uploadButton?: ReactNode) {
     const {
-      listType, sortable, listLimit, showHistory, showSize, previewTarget, buttons, getPreviewUrl, disabled, 
+      listType, sortable, listLimit, showHistory, showSize, previewTarget, buttons, getPreviewUrl, disabled, getDownloadUrl,
     } = this.props;
     let mergeButtons:AttachmentButtons[]  = [AttachmentButtonType.download, AttachmentButtonType.remove];
     if (buttons) {
@@ -1065,13 +1068,20 @@ export default class Attachment extends FormField<AttachmentProps> {
           getPreviewUrl={getPreviewUrl}
           fetchAttachmentsFlag={!this.uploadWithoutUuid}
           removeConfirm={this.removeConfirm}
+          getDownloadUrl={getDownloadUrl}
         />
       );
     }
   }
 
   renderHeader(uploadBtn?: ReactNode) {
-    const { prefixCls, count, props: { downloadAll, viewMode, __inGroup } } = this;
+    const { prefixCls, count, props: {
+      downloadAll,
+      viewMode,
+      __inGroup,
+      downloadAllMode: downloadAllModeProp,
+      getDownloadAllUrl: getDownloadAllUrlProp,
+    } } = this;
     const label = (!__inGroup || count) && this.renderHeaderLabel();
     const buttons: ReactNode[] = [];
     if (uploadBtn) {
@@ -1080,11 +1090,15 @@ export default class Attachment extends FormField<AttachmentProps> {
         this.renderTemplateDownloadButton(),
       );
     }
-    const { downloadAllMode = DownloadAllMode.readOnly } = this.getContextConfig('attachment');
+    const {
+      downloadAllMode: downloadAllModeConfig,
+      getDownloadAllUrl: getDownloadAllUrlConfig,
+    } = this.getContextConfig('attachment');
+    const downloadAllMode = downloadAllModeProp || downloadAllModeConfig || DownloadAllMode.readOnly;
     if ((downloadAllMode === DownloadAllMode.readOnly && this.readOnly) || (downloadAllMode === DownloadAllMode.always)) {
       if (this.count) {
         if (downloadAll) {
-          const { getDownloadAllUrl } = this.getContextConfig('attachment');
+          const getDownloadAllUrl = getDownloadAllUrlProp || getDownloadAllUrlConfig;
           if (getDownloadAllUrl) {
             const attachmentUUID = this.getValue();
             if (attachmentUUID) {

--- a/components-pro/attachment/AttachmentList.tsx
+++ b/components-pro/attachment/AttachmentList.tsx
@@ -46,6 +46,7 @@ export interface AttachmentListProps {
    */
   fetchAttachmentsFlag: boolean;
   removeConfirm?: boolean | PopconfirmProps;
+  getDownloadUrl?: (props: AttachmentFileProps) => string | Function | undefined;
 }
 
 const AttachmentList: FunctionComponent<AttachmentListProps> = function AttachmentList(props) {
@@ -78,6 +79,7 @@ const AttachmentList: FunctionComponent<AttachmentListProps> = function Attachme
     buttons,
     getPreviewUrl,
     removeConfirm,
+    getDownloadUrl,
   } = props;
   const isCard = listType === 'picture-card';
   const classString = classNames(prefixCls, isCard ? `${prefixCls}-card` : `${prefixCls}-no-card`);
@@ -157,6 +159,7 @@ const AttachmentList: FunctionComponent<AttachmentListProps> = function Attachme
                 buttons={buttons}
                 getPreviewUrl={getPreviewUrl}
                 removeConfirm={removeConfirm}
+                getDownloadUrl={getDownloadUrl}
               />
             )
           }

--- a/components-pro/attachment/index.en-US.md
+++ b/components-pro/attachment/index.en-US.md
@@ -27,27 +27,27 @@ title: Attachment
 | listType | 上传列表的内建样式，支持三种基本样式 `text`, `picture` 和 `picture-card` | string | 'text' |
 | viewMode | 上传列表的显示模式，支持三种基本样式 `none`, `list` 和 `popup` | string | 'list' |
 | sortable | 是否可排序, 只读模式下不可拖拽 | boolean | true |
-| fileKey | 上传文件的参数名 | string | [attachment.defaultFileKey](/component/configure/#Attachment) |
-| fileSize | 上传文件的大小限制, 单位 `B` | number | [attachment.defaultFileSize](/component/configure/#Attachment) |
+| fileKey | 上传文件的参数名 | string | [attachment.defaultFileKey](/components/configure/#AttachmentConfig) |
+| fileSize | 上传文件的大小限制, 单位 `B` | number | [attachment.defaultFileSize](/components/configure/#AttachmentConfig) |
 | useChunk | 是否开启分片上传 | boolean |  |
-| chunkSize | 分片大小 | number | [attachment.defaultChunkSize](/component/configure/#Attachment) |
-| chunkThreads | 分片上传并发数 | number | [attachment.defaultChunkThreads](/component/configure/#Attachment) |
+| chunkSize | 分片大小 | number | [attachment.defaultChunkSize](/components/configure/#AttachmentConfig) |
+| chunkThreads | 分片上传并发数 | number | [attachment.defaultChunkThreads](/components/configure/#AttachmentConfig) |
 | pictureWidth | 图片尺寸， 只适用于 listType 为 picture 和 picture-card | number |  |
 | count | 自定义附件数量 | number |  |
 | max | 同时上传文件的最大数量, `0` 表示无限制 | number |  |
 | listLimit | 上传列表最大显示数量，只适用于只读模式 | number |  |
 | showHistory | 可显示操作历史记录 | boolean |  |
 | showSize | 显示文件大小信息 | boolean | true |
-| downloadAll | 是否显示全部下载按钮，只适用于只读模式， 必须配置[attachment.getDownloadAllUrl](/component/configure/#Attachment) | boolean \| ButtonProps | true |
+| downloadAll | 是否显示全部下载按钮，只适用于只读模式， 必须配置[attachment.getDownloadAllUrl](/components/configure/#AttachmentConfig) | boolean \| ButtonProps | true |
 | bucketName | 附件上传的桶名 | string |  |
 | bucketDirectory | 附件上传的桶目录 | string |  |
 | storageCode | 附件存储编码 | string |  |
 | template | 附件模板 | { bucketName?: string, bucketDirectory?: string, storageCode?:string, attachmentUUID: string, isPublic?: boolean } |  |
 | previewTarget | 预览链接跳转对象， 如要在iframe内预览， 可给 iframe 指定 name={previewTarget} | string | 'attachment-preview'  |
-| isPublic | 是否是公共的， [attachment](/component/configure/#Attachment)配置中相关钩子会使用该属性 | boolean |  |
+| isPublic | 是否是公共的， [attachment](/components/configure/#AttachmentConfig)配置中相关钩子会使用该属性 | boolean |  |
 | attachments | 附件列表 | (AttachmentFile \| FileLike)[] |  |
 | showValidation | 校验信息展示方式 | `newLine` \| `tooltip` | `viewMode` == `popup` ? `tooltip` : `newLine` |
-| getUUID | 获取 uuid | () => Promise<string> \| string | [attachment.getAttachmentUUID](/component/configure/#Attachment) |
+| getUUID | 获取 uuid | () => Promise<string> \| string | [attachment.getAttachmentUUID](/components/configure/#AttachmentConfig) |
 | buttons | 功能按钮，默认存在`download` 和 `remove`值，可传递数组、自定义按钮或按钮配置属性对象，数组为可选值字符串+按钮配置属性对象（非默认按钮需添加唯一 key） | string[] \| \[string, object\] \| ReactNode[] \| object | [['download', 'remove']] |
 | onAttachmentsChange | 附件列表变更事件 | (AttachmentFile[]) => void |  |
 | beforeUpload | 上传文件之前的钩子，参数为上传的文件，可对文件在上传之前进行校验操作若返回 false 则停止上传并从列表充删除。支持返回一个 Promise 对象，Promise 对象 reject 或 resolve(false) 时则停止上传，resolve 时开始上传。 | (attachment: AttachmentFile, list: AttachmentFile[]) => (boolean \| Promise) | - |
@@ -61,10 +61,13 @@ title: Attachment
 | countTextRenderer | 上传按钮中数量显示 renderer | (count?: number, max?: number, defaultCountText?: ReactNode) => ReactNode |  |
 | removeConfirm | 删除前确认气泡框配置 | boolean \| PopconfirmProps | |
 | templateDownloadButtonRenderer | 自定义下载模板按钮，使用后需完全自定义下载模板相关逻辑 | () => ReactNode | |
+| downloadAllMode | 显示全部下载按钮模式 | readOnly \| always | 'readOnly' |
+| getDownloadAllUrl | 获取全部下载地址，返回值类型为函数时作为按钮的点击事件 | ({ bucketName?: string, bucketDirectory?: string, storageCode?:string, attachmentUUID: string, isPublic?: boolean }) => string \| Function \| undefined |  |
+| getDownloadUrl | 获取下载地址，返回值类型为函数时作为按钮的点击事件，默认使用 AttachmentFile.url | ({ attachment: AttachmentFile, bucketName?: string, bucketDirectory?: string, storageCode?:string, attachmentUUID: string, isPublic?: boolean }) => string \| Function \| undefined | [attachment.getDownloadUrl](/components/configure/#AttachmentConfig) |
 
 更多属性请参考 [FormField](/components-pro/field/#FormField) 和 [Button](/components-pro/button/#Button)。
 附件对象参考 [AttachmentFile](/components-pro/data-set/#AttachmentFile)
-全局配置参考 [attachment](/component/configure/#Attachment)
+全局配置参考 [attachment](/components/configure/#AttachmentConfig)
 
 ### Attachment.Group
 

--- a/components-pro/attachment/index.zh-CN.md
+++ b/components-pro/attachment/index.zh-CN.md
@@ -27,27 +27,27 @@ title: Attachment
 | listType | 上传列表的内建样式，支持三种基本样式 `text`, `picture` 和 `picture-card` | string | 'text' |
 | viewMode | 上传列表的显示模式，支持三种基本样式 `none`, `list` 和 `popup` | string | 'list' |
 | sortable | 是否可排序, 只读模式下不可拖拽 | boolean | true |
-| fileKey | 上传文件的参数名 | string | [attachment.defaultFileKey](/component/configure/#Attachment) |
-| fileSize | 上传文件的大小限制, 单位 `B` | number | [attachment.defaultFileSize](/component/configure/#Attachment) |
+| fileKey | 上传文件的参数名 | string | [attachment.defaultFileKey](/components/configure/#AttachmentConfig) |
+| fileSize | 上传文件的大小限制, 单位 `B` | number | [attachment.defaultFileSize](/components/configure/#AttachmentConfig) |
 | useChunk | 是否开启分片上传 | boolean |  |
-| chunkSize | 分片大小 | number | [attachment.defaultChunkSize](/component/configure/#Attachment) |
-| chunkThreads | 分片上传并发数 | number | [attachment.defaultChunkThreads](/component/configure/#Attachment) |
+| chunkSize | 分片大小 | number | [attachment.defaultChunkSize](/components/configure/#AttachmentConfig) |
+| chunkThreads | 分片上传并发数 | number | [attachment.defaultChunkThreads](/components/configure/#AttachmentConfig) |
 | pictureWidth | 图片尺寸， 只适用于 listType 为 picture 和 picture-card | number |  |
 | count | 自定义附件数量 | number |  |
 | max | 同时上传文件的最大数量, `0` 表示无限制 | number |  |
 | listLimit | 上传列表最大显示数量，只适用于只读模式 | number |  |
 | showHistory | 可显示操作历史记录 | boolean |  |
 | showSize | 显示文件大小信息 | boolean | true |
-| downloadAll | 是否显示全部下载按钮，只适用于只读模式， 必须配置[attachment.getDownloadAllUrl](/component/configure/#Attachment) | boolean \| ButtonProps | true |
+| downloadAll | 是否显示全部下载按钮，只适用于只读模式， 必须配置[attachment.getDownloadAllUrl](/components/configure/#AttachmentConfig) | boolean \| ButtonProps | true |
 | bucketName | 附件上传的桶名 | string |  |
 | bucketDirectory | 附件上传的桶目录 | string |  |
 | storageCode | 附件存储编码 | string |  |
 | template | 附件模板 | { bucketName?: string, bucketDirectory?: string, storageCode?:string, attachmentUUID: string, isPublic?: boolean } |  |
 | previewTarget | 预览链接跳转对象， 如要在iframe内预览， 可给 iframe 指定 name={previewTarget} | string | 'attachment-preview'  |
-| isPublic | 是否是公共的， [attachment](/component/configure/#Attachment)配置中相关钩子会使用该属性 | boolean |  |
+| isPublic | 是否是公共的， [attachment](/components/configure/#AttachmentConfig)配置中相关钩子会使用该属性 | boolean |  |
 | attachments | 附件列表 | (AttachmentFile \| FileLike)[] |  |
 | showValidation | 校验信息展示方式 | `newLine` \| `tooltip` | `viewMode` == `popup` ? `tooltip` : `newLine` |
-| getUUID | 获取 uuid | () => Promise<string> \| string | [attachment.getAttachmentUUID](/component/configure/#Attachment) |
+| getUUID | 获取 uuid | () => Promise<string> \| string | [attachment.getAttachmentUUID](/components/configure/#AttachmentConfig) |
 | buttons | 功能按钮，默认存在`download` 和 `remove`值，可传递数组、自定义按钮或按钮配置属性对象，数组为可选值字符串+按钮配置属性对象（非默认按钮需添加唯一 key） | string[] \| \[string, object\] \| ReactNode[] \| object | [['download', 'remove']] |
 | onAttachmentsChange | 附件列表变更事件 | (AttachmentFile[]) => void |  |
 | beforeUpload | 上传文件之前的钩子，参数为上传的文件，可对文件在上传之前进行校验操作若返回 false 则停止上传并从列表充删除。支持返回一个 Promise 对象，Promise 对象 reject 或 resolve(false) 时则停止上传，resolve 时开始上传。 | (attachment: AttachmentFile, list: AttachmentFile[]) => (boolean \| Promise) | - |
@@ -61,10 +61,13 @@ title: Attachment
 | countTextRenderer | 上传按钮中数量显示 renderer | (count?: number, max?: number, defaultCountText?: ReactNode) => ReactNode |  |
 | removeConfirm | 删除前确认气泡框配置 | boolean \| PopconfirmProps | |
 | templateDownloadButtonRenderer | 自定义下载模板按钮，使用后需完全自定义下载模板相关逻辑 | () => ReactNode | |
+| downloadAllMode | 显示全部下载按钮模式 | readOnly \| always | 'readOnly' |
+| getDownloadAllUrl | 获取全部下载地址，返回值类型为函数时作为按钮的点击事件 | ({ bucketName?: string, bucketDirectory?: string, storageCode?:string, attachmentUUID: string, isPublic?: boolean }) => string \| Function \| undefined |  |
+| getDownloadUrl | 获取下载地址，返回值类型为函数时作为按钮的点击事件，默认使用 AttachmentFile.url | ({ attachment: AttachmentFile, bucketName?: string, bucketDirectory?: string, storageCode?:string, attachmentUUID: string, isPublic?: boolean }) => string \| Function \| undefined | [attachment.getDownloadUrl](/components/configure/#AttachmentConfig) |
 
 更多属性请参考 [FormField](/components-pro/field/#FormField) 和 [Button](/components-pro/button/#Button)。
 附件对象参考 [AttachmentFile](/components-pro/data-set/#AttachmentFile)
-全局配置参考 [attachment](/component/configure/#Attachment)
+全局配置参考 [attachment](/components/configure/#AttachmentConfig)
 
 ### Attachment.Group
 

--- a/components-pro/tree/index.tsx
+++ b/components-pro/tree/index.tsx
@@ -451,7 +451,9 @@ export default class Tree extends Component<TreeProps> {
     return Promise.all(promises).then(action(() => {
       this.stateLoadedKeys.push(event.key);
 
-      this.handleAfterLoadData(event);
+      if (promises.length) {
+        this.handleAfterLoadData(event);
+      }
     }));
   }
 
@@ -459,7 +461,7 @@ export default class Tree extends Component<TreeProps> {
   handleAfterLoadData(event): void {
     const { dataSet, selectable } = this.props;
     if (dataSet && selectable === false) {
-      const { checkField, idField } = dataSet.props;
+      const { checkField, idField, treeCheckStrictly } = dataSet.props;
       const loadRootRecord = dataSet.find(record => getKey(record, idField) === String(event.key));
       if (!loadRootRecord) {
         return;
@@ -473,12 +475,14 @@ export default class Tree extends Component<TreeProps> {
             dataSet.select(record);
           }
         });
-        if (!loadRootRecord.isSelected && loadRecords.every(record => record.isSelected)) {
-          dataSet.select(loadRootRecord);
-        } else if (loadRootRecord.isSelected && loadRecords.some(record => !record.isSelected)) {
-          dataSet.unSelect(loadRootRecord);
+        if (!treeCheckStrictly) {
+          if (!loadRootRecord.isSelected && loadRecords.every(record => record.isSelected)) {
+            dataSet.select(loadRootRecord);
+          } else if (loadRootRecord.isSelected && loadRecords.some(record => !record.isSelected)) {
+            dataSet.unSelect(loadRootRecord);
+          }
         }
-      } else if (event.checked) {
+      } else if (!treeCheckStrictly && event.checked) {
         loadRecords.forEach(record => {
           dataSet.select(record);
         });


### PR DESCRIPTION
…ownloadUrl properties. & [IMP] <pro>Attachment: The upload failed and Tooltip is displayed if the error text is too long. & [FIX] <pro>Tree: Fixed an issue where the checked node expansion would be unchecked when the dataSet set the treeCheckStrictly attribute.