### PR TITLE
[IMP] <pro>Select: When setting the disabled attribute for the option…

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -28,6 +28,7 @@ timeline: true
 - 💄 `<pro>Table`: Optimize the group names of the filtering conditions for the dynamic filtering bar.
 - 💄 `<pro>Attachment`: Check if access is available before uploading the file.
 - 💄 `<pro>Table`: Execute the query upon completion of initialization for default conditions of the dynamic filter bar.
+- 💄 `<pro>Select`: When setting the `disabled` attribute for the `options.record` setting, disable the option.
 - 🐞 `<pro>Attachment`: Fixed the issue where the count of attachments could not be obtained through the field property `attachmentCount` in `onAttachmentsChange` when uploading a file for the first time.
 - 🐞 `<pro>Attachment`: Fixed an issue where the `getPreviewUrl` property of the configuration component could cause abnormal refreshing of thumbnails in the attachment list.
 - 🐞 `<pro>Lov`: Fixed the issue where the order of selected data was inconsistent with the initial selection order when reopening the modal.
@@ -41,6 +42,8 @@ timeline: true
 - 🐞 `<pro>Table`: Fix the issue where, when the `rowBoxPlacement` property is set to `end`, the collapse `icon` in the tree view mode is displayed in the second column.
 - 🐞 `<pro>Table`: Fixed the issue where input boxes rendered through the `renderer` could not move the cursor using the arrow keys.
 - 🐞 `<pro>Table`: Fix the style issue where the icon in the `range` mode Select of the `filterBar` type filter bar overlaps.
+- 🐞 `<pro>Lov`: When closing the pop-up window, there is only one piece of data on the last page. When reopening the pop-up window, the problem recorded will be automatically selected.
+- 🐞 `<pro>Tooltip`: Fix the issue where the occasional prompt window does not display in the singleton mode.
 
 ## 1.6.8
 

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -28,6 +28,7 @@ timeline: true
 - 💄 `<pro>Table`: 优化动态筛选条的筛选条件的分组名。
 - 💄 `<pro>Attachment`: 文件上传前检查是否可访问。
 - 💄 `<pro>Table`: 优化动态筛选条默认查询条件就绪后再执行查询。
+- 💄 `<pro>Select`: 优化 options.record 设置 disabled 属性时, 禁用选项。
 - 🐞 `<pro>Attachment`: 修复首次上传文件在 onAttachmentsChange 中通过字段属性 attachmentCount 获取不到附件数量的问题。
 - 🐞 `<pro>Attachment`: 修复配置组件属性 getPreviewUrl 可能会导致附件列表中的缩略图异常刷新的问题。
 - 🐞 `<pro>Lov`: 修复再次打开弹框时已勾选数据顺序与初次勾选顺序不一致的问题。
@@ -41,6 +42,8 @@ timeline: true
 - 🐞 `<pro>Table`: 修复当 rowBoxPlacement 属性设置为 end 时, 树形模式的折叠 icon 显示到了第二列的问题。
 - 🐞 `<pro>Table`: 修复通过 renderer 渲染的输入框无法通过方向键控制光标移动的问题。
 - 🐞 `<pro>Table`: 修复 filterBar 类型筛选条中 range 模式下拉框的图标重叠的样式问题。
+- 🐞 `<pro>Lov`: 在关闭弹窗时最后一页只有一条数据, 再次打开弹窗时, 会自动选中记录的问题。
+- 🐞 `<pro>Tooltip`: 修复单例模式下偶现提示弹窗不显示的问题。
 
 ## 1.6.8
 

--- a/components-pro/lov/Lov.tsx
+++ b/components-pro/lov/Lov.tsx
@@ -981,15 +981,17 @@ export default class Lov extends Select<LovProps> {
     const { options } = this;
     this.resetOptions(options.length === 1);
     await options.query(1, undefined, true);
-    if (options.length === 1) {
-      const values = this.getValues();
-      const record = options.get(0);
-      if (!this.optionIsSelected(record as Record, values)) {
-        this.choose(record);
+    options.ready().then(() => {
+      if (options.length === 1) {
+        const values = this.getValues();
+        const record = options.get(0);
+        if (!this.optionIsSelected(record as Record, values)) {
+          this.choose(record);
+        }
+      } else {
+        this.openModal();
       }
-    } else {
-      this.openModal();
-    }
+    });
   }
 
   @autobind

--- a/components-pro/select/Select.tsx
+++ b/components-pro/select/Select.tsx
@@ -910,6 +910,11 @@ export class Select<T extends SelectProps = SelectProps> extends TriggerField<T>
         tooltipTheme: getTooltipTheme('select-option'),
         tooltipPlacement: getTooltipPlacement('select-option'),
       };
+      const itemDisabled = optionProps
+        ? (optionProps.disabled === false
+          ? (itemProps.disabled || optionProps.disabled)
+          : (itemProps.disabled || optionProps.disabled || record.disabled || record.selectable === false))
+        : (itemProps.disabled || record.disabled || record.selectable === false);
       const mergedProps = optionProps ? {
         ...optionProps,
         ...itemProps,
@@ -920,8 +925,11 @@ export class Select<T extends SelectProps = SelectProps> extends TriggerField<T>
           ...optionProps.style,
           ...itemProps.style,
         },
-        disabled: itemProps.disabled || optionProps.disabled,
-      } : itemProps;
+        disabled: itemDisabled,
+      } : {
+        ...itemProps,
+        disabled: itemDisabled,
+      };
       const option: ReactElement = (
         <Item {...mergedProps}>
           {toJS(itemContent)}

--- a/components-pro/tooltip/singleton.tsx
+++ b/components-pro/tooltip/singleton.tsx
@@ -92,7 +92,7 @@ function getRoot() {
 
 async function getContainer(): Promise<RefObject<TooltipContainerRef>> {
   const { container } = TooltipManager;
-  if (container) {
+  if (container && container.current) {
     return container;
   }
   return new Promise(resolve => {


### PR DESCRIPTION
…s.record setting, disable the option. & [FIX] <pro>Lov: When closing the pop-up window, there is only one piece of data on the last page. When reopening the pop-up window, the problem recorded will be automatically selected. & [FIX] <pro>Tooltip: Fix the issue where the occasional prompt window does not display in the singleton mode.